### PR TITLE
Fixed dragging across districts and dragging to districts

### DIFF
--- a/src/hooks/useDragToSelect.ts
+++ b/src/hooks/useDragToSelect.ts
@@ -84,9 +84,9 @@ export const useDragToSelect = ({ board }: UseDragToSelectProps) => {
       return false;
     }
 
-    // For a new selection, check if voter can be added to current district
     if (selection.size === 0) {
-      return canAddVoterToCurrentDistrict(voter);
+      // let addMultipleVotersToDistrict handle complex logic
+      return true;
     }
 
     // Don't add the same voter twice
@@ -103,7 +103,7 @@ export const useDragToSelect = ({ board }: UseDragToSelectProps) => {
       return false;
     }
 
-    // Let addMultipleVotersToDistrict handle adjacency checks
+    // let addMultipleVotersToDistrict handle complex logic
     return true;
   };
 

--- a/src/hooks/useDragToSelect.ts
+++ b/src/hooks/useDragToSelect.ts
@@ -103,10 +103,8 @@ export const useDragToSelect = ({ board }: UseDragToSelectProps) => {
       return false;
     }
 
-    // Check adjacency - voter must be adjacent to at least one voter in current selection
-    return Array.from(selection).some((existingVoter) =>
-      isAdjacent(existingVoter, voter),
-    );
+    // Let addMultipleVotersToDistrict handle adjacency checks
+    return true;
   };
 
   // Helper function to check if a voter can be removed from current district


### PR DESCRIPTION
bug 1: now the player can create a partial district and then click and drag across it to the add to the district

https://github.com/user-attachments/assets/d3a37288-0c33-4835-b207-1a2cd3c64a35

bug 2: now the player can create a partial district and then click far away from the district and drag into the district

https://github.com/user-attachments/assets/b777d6f8-52b0-41a3-8faf-a59270c6cb66




