### PR TITLE
fix: district = geographical group

### DIFF
--- a/src/app/districts/page.tsx
+++ b/src/app/districts/page.tsx
@@ -9,7 +9,7 @@ import ArrowLeftIcon from '@/icons/ArrowLeftIcon';
 export const metadata: Metadata = {
   title: 'The Gerrymanderer: Draw the district',
   description:
-    'A group of voters where the majority wins—often drawn with the creativity of a villainous Michelangelo.',
+    'A geographical group of voters where the majority wins—often drawn with the creativity of a villainous Michelangelo.',
 };
 
 export default function Districts() {
@@ -19,7 +19,7 @@ export default function Districts() {
       <Definition
         term="District"
         pronunciation="/ˈdistrikt/ (noun)"
-        definition="A group of voters where the majority wins—often drawn with the creativity of a villainous Michelangelo."
+        definition="A geographical group of voters where the majority wins—often drawn with the creativity of a villainous Michelangelo."
       />
       <DistrictAnimation />
       <Text>Tap or swipe to draw a district.</Text>


### PR DESCRIPTION
Not a full fix for this obviously but a step in the right direction:

<img width="383" height="193" alt="image" src="https://github.com/user-attachments/assets/f315594c-41a4-4923-a01d-b53c3b9ac23f" />
